### PR TITLE
Make sure invariant culture is used for number parsing

### DIFF
--- a/src/TestDataGenerator.Core.Tests/TextTests.cs
+++ b/src/TestDataGenerator.Core.Tests/TextTests.cs
@@ -486,7 +486,7 @@ namespace TestDataGenerator.Tests
             var template = @"<<[100-150]>>";
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
-            int e = int.Parse(text);
+            int e = int.Parse(text, CultureInfo.InvariantCulture);
             if(e < 100 || e>150) Assert.Fail("Number not between 100 and 150.");
         }
 
@@ -518,7 +518,7 @@ namespace TestDataGenerator.Tests
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
             double d;
-            if (!double.TryParse(text, out d))
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                 Assert.Fail();
             if(d<1.00 || d>10.00d) Assert.Fail();
         }
@@ -531,7 +531,7 @@ namespace TestDataGenerator.Tests
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
             double d;
-            if (!double.TryParse(text, out d))
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                 Assert.Fail();
             if (d < 1.00 || d > 2.00d) Assert.Fail();
         }
@@ -544,7 +544,7 @@ namespace TestDataGenerator.Tests
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
             double d;
-            if (!double.TryParse(text, out d))
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                 Assert.Fail();
             if (d < 1.1 || d > 1.2d) Assert.Fail();
         }
@@ -557,7 +557,7 @@ namespace TestDataGenerator.Tests
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
             double d;
-            if (!double.TryParse(text, out d))
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                 Assert.Fail();
             if (d < 12345.12345 || d > 12345.12346d) Assert.Fail();
         }
@@ -570,7 +570,7 @@ namespace TestDataGenerator.Tests
             string text = AlphaNumericGenerator.GenerateFromTemplate(template);
             Console.WriteLine(@"'{0}' produced '{1}'", template, text);
             double d;
-            if (!double.TryParse(text, out d))
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out d))
                 Assert.Fail();
             if (d < 12345.9999d || d > 12346d) Assert.Fail();
         }

--- a/src/TestDataGenerator.Core/Generators/AlphaNumericGenerator.cs
+++ b/src/TestDataGenerator.Core/Generators/AlphaNumericGenerator.cs
@@ -544,7 +544,7 @@ namespace TestDataGenerator.Core.Generators
             string possibles=_ShortHands["."];
             var items = range.Split('-');
             double i = 0;
-            if (!Double.TryParse(items[0], out i))
+            if (!Double.TryParse(items[0], NumberStyles.Any, CultureInfo.InvariantCulture, out i))
                 ret = GetRandomAlphaItemFromRange(isNegated, random, items, possibles);
             else
                 ret = GetRandomNumericItemFromRange(isNegated, random, items, possibles);
@@ -574,10 +574,10 @@ namespace TestDataGenerator.Core.Generators
             string ret = "";
 
             double min;
-            if (double.TryParse(items[0], out min))
+            if (double.TryParse(items[0], NumberStyles.Any, CultureInfo.InvariantCulture, out min))
             {
                 double max;
-                if (double.TryParse(items[1], out max))
+                if (double.TryParse(items[1], NumberStyles.Any, CultureInfo.InvariantCulture, out max))
                 {
                     int scale = 0;
                     if (items[0].Contains("."))
@@ -641,7 +641,7 @@ namespace TestDataGenerator.Core.Generators
                 var vals = repeatExpression.Split(',');
                 int min, max;
 
-                if (vals.Length < 2 || !int.TryParse(vals[0], out min) || !int.TryParse(vals[1], out max) || min > max || min < 0)
+                if (vals.Length < 2 || !int.TryParse(vals[0], NumberStyles.Any, CultureInfo.InvariantCulture, out min) || !int.TryParse(vals[1], NumberStyles.Any, CultureInfo.InvariantCulture, out max) || min > max || min < 0)
                 {
                     var msg = "Invalid repeat section, random length parameters must be in the format {min,max} where min and max are greater than zero and min is less than max.\n";
                     msg += BuildErrorSnippet(repeatExpression, 0);
@@ -650,7 +650,8 @@ namespace TestDataGenerator.Core.Generators
 
                 repeat = random.Next(min, max + 1);
             }
-            else if (!int.TryParse(repeatExpression, out repeat)) repeat = -1;
+            else if (!int.TryParse(repeatExpression, NumberStyles.Any, CultureInfo.InvariantCulture, out repeat))
+                repeat = -1;
 
             if (repeat < 0)
                 throw new GenerationException("Invalid repeat section, repeat value must not be less than zero. '"+repeatExpression+"'");


### PR DESCRIPTION
This pull request aims to fix problems for users having "," configured as the decimal separator in OS's regional settings. For more info: https://en.wikipedia.org/wiki/Decimal_mark

5 tests fail when comma is defined as the decimal separator. So I think "." should be used as the universal default ([somewhat similar to W3C guides](https://www.w3.org/TR/html5/infrastructure.html#valid-floating-point-number)) and all number parsing should be performed through invariant culture rules.
